### PR TITLE
Return the exit code in ScriptExecutor

### DIFF
--- a/src/Microsoft.Framework.PackageManager/Building/BuildManager.cs
+++ b/src/Microsoft.Framework.PackageManager/Building/BuildManager.cs
@@ -70,7 +70,12 @@ namespace Microsoft.Framework.PackageManager
                 frameworks = new[] { _applicationEnvironment.RuntimeFramework };
             }
 
-            ScriptExecutor.Execute(project, "prebuild", GetScriptVariable);
+
+            if (!ScriptExecutor.Execute(project, "prebuild", GetScriptVariable))
+            {
+                WriteError(ScriptExecutor.ErrorMessage);
+                return false;
+            }
 
             var success = true;
 
@@ -177,7 +182,11 @@ namespace Microsoft.Framework.PackageManager
                 }
             }
 
-            ScriptExecutor.Execute(project, "postbuild", GetScriptVariable);
+            if (!ScriptExecutor.Execute(project, "postbuild", GetScriptVariable))
+            {
+                WriteError(ScriptExecutor.ErrorMessage);
+                return false;
+            }
 
             sw.Stop();
 

--- a/src/Microsoft.Framework.PackageManager/Packing/PackManager.cs
+++ b/src/Microsoft.Framework.PackageManager/Packing/PackManager.cs
@@ -95,9 +95,17 @@ namespace Microsoft.Framework.PackageManager.Packing
                 return null;
             };
 
-            ScriptExecutor.Execute(project, "prepare", getVariable);
+            if (!ScriptExecutor.Execute(project, "prepare", getVariable))
+            {
+                _options.Reports.Error.WriteLine(ScriptExecutor.ErrorMessage);
+                return false;
+            }
 
-            ScriptExecutor.Execute(project, "prepack", getVariable);
+            if (!ScriptExecutor.Execute(project, "prepack", getVariable))
+            {
+                _options.Reports.Error.WriteLine(ScriptExecutor.ErrorMessage);
+                return false;
+            }
 
             foreach (var runtime in _options.Runtimes)
             {
@@ -245,7 +253,11 @@ namespace Microsoft.Framework.PackageManager.Packing
 
             root.Emit();
 
-            ScriptExecutor.Execute(project, "postpack", getVariable);
+            if (!ScriptExecutor.Execute(project, "postpack", getVariable))
+            {
+                _options.Reports.Error.WriteLine(ScriptExecutor.ErrorMessage);
+                return false;
+            }
 
             if (_options.Native && !nativeImageGenerator.BuildNativeImages(root))
             {


### PR DESCRIPTION
Solving issue #987

Now the exit code from the script in project.json need to be zero to ensure a successful build/pack/restore.