### PR TITLE
"kpm restore" ignores nonexistent local package feeds and gives warnings

### DIFF
--- a/src/Microsoft.Framework.PackageManager/Commands/InstallCommand.cs
+++ b/src/Microsoft.Framework.PackageManager/Commands/InstallCommand.cs
@@ -55,15 +55,14 @@ namespace Microsoft.Framework.PackageManager
             var packageFeeds = new List<IPackageFeed>();
             foreach (var source in effectiveSources)
             {
-                if (new Uri(source.Source).IsFile)
+                var feed = PackageSourceUtils.CreatePackageFeed(
+                    source,
+                    _restoreCommand.NoCache,
+                    _restoreCommand.IgnoreFailedSources,
+                    Reports);
+                if (feed != null)
                 {
-                    packageFeeds.Add(PackageFolderFactory.CreatePackageFolderFromPath(source.Source, Reports.Quiet));
-                }
-                else
-                {
-                    packageFeeds.Add(new NuGetv2Feed(
-                        source.Source, source.UserName, source.Password, _restoreCommand.NoCache, Reports,
-                        _restoreCommand.IgnoreFailedSources));
+                    packageFeeds.Add(feed);
                 }
             }
 

--- a/src/Microsoft.Framework.PackageManager/Restore/NuGet/IPackageFeed.cs
+++ b/src/Microsoft.Framework.PackageManager/Restore/NuGet/IPackageFeed.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Framework.PackageManager.Restore.NuGet
 {
     public interface IPackageFeed
     {
+        string Source { get; }
         Task<IEnumerable<PackageInfo>> FindPackagesByIdAsync(string id);
         Task<Stream> OpenNupkgStreamAsync(PackageInfo package);
         Task<Stream> OpenNuspecStreamAsync(PackageInfo package);

--- a/src/Microsoft.Framework.PackageManager/Restore/NuGet/KpmPackageFolder.cs
+++ b/src/Microsoft.Framework.PackageManager/Restore/NuGet/KpmPackageFolder.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using System.IO;
-using System.IO.Compression;
 using System.Linq;
 using System.Threading.Tasks;
 using NuGet;
@@ -12,36 +11,68 @@ namespace Microsoft.Framework.PackageManager.Restore.NuGet
 {
     public class KpmPackageFolder : IPackageFeed
     {
-        private readonly IReport _report;
+        private bool _ignored;
+        private readonly bool _ignoreFailure;
+        private readonly Reports _reports;
         private readonly PackageRepository _repository;
         private readonly IFileSystem _fileSystem;
         private readonly IPackagePathResolver _pathResolver;
 
+        public string Source { get; }
+
         public KpmPackageFolder(
             string physicalPath,
-            IReport report)
+            bool ignoreFailure,
+            Reports reports)
         {
             // We need to help "kpm restore" to ensure case-sensitivity here
             // Turn on the flag to get package ids in accurate casing
             _repository = new PackageRepository(physicalPath, checkPackageIdCase: true);
             _fileSystem = new PhysicalFileSystem(physicalPath);
             _pathResolver = new DefaultPackagePathResolver(_fileSystem);
-            _report = report;
+            _reports = reports;
+            Source = physicalPath;
+            _ignored = false;
+            _ignoreFailure = ignoreFailure;
         }
 
         public Task<IEnumerable<PackageInfo>> FindPackagesByIdAsync(string id)
         {
-            return Task.FromResult(_repository.FindPackagesById(id).Select(p => new PackageInfo
+            if (_ignored)
             {
-                Id = p.Id,
-                Version = p.Version
-            }));
+                return Task.FromResult(Enumerable.Empty<PackageInfo>());
+            }
+
+            if (Directory.Exists(Source))
+            {
+                return Task.FromResult(_repository.FindPackagesById(id).Select(p => new PackageInfo
+                {
+                    Id = p.Id,
+                    Version = p.Version
+                }));
+            }
+
+            var exception = new FileNotFoundException(
+                message: string.Format("The local package source {0} doesn't exist", Source.Bold()),
+                fileName: Source);
+
+            if (_ignoreFailure)
+            {
+                _reports.Information.WriteLine(string.Format("Warning: FindPackagesById: {1}\r\n  {0}",
+                    exception.Message, id.Yellow().Bold()));
+                _ignored = true;
+                return Task.FromResult(Enumerable.Empty<PackageInfo>());
+            }
+
+            _reports.Error.WriteLine(string.Format("Error: FindPackagesById: {1}\r\n  {0}",
+                exception.Message, id.Red().Bold()));
+            throw exception;
         }
 
         public Task<Stream> OpenNuspecStreamAsync(PackageInfo package)
         {
             var nuspecPath = _pathResolver.GetManifestFilePath(package.Id, package.Version);
-            _report.WriteLine(string.Format("  OPEN {0}", _fileSystem.GetFullPath(nuspecPath)));
+            _reports.Quiet.WriteLine(string.Format("  OPEN {0}", _fileSystem.GetFullPath(nuspecPath)));
             return Task.FromResult<Stream>(File.OpenRead(nuspecPath));
         }
 
@@ -51,7 +82,7 @@ namespace Microsoft.Framework.PackageManager.Restore.NuGet
             var unzippedPackage = new UnzippedPackage(_fileSystem, nuspecPath);
 
             var nupkgPath = _pathResolver.GetPackageFilePath(package.Id, package.Version);
-            _report.WriteLine(string.Format("  OPEN {0}", _fileSystem.GetFullPath(nupkgPath)));
+            _reports.Quiet.WriteLine(string.Format("  OPEN {0}", _fileSystem.GetFullPath(nupkgPath)));
 
             return Task.FromResult(unzippedPackage.GetStream());
         }

--- a/src/Microsoft.Framework.PackageManager/Restore/NuGet/NuGetPackageFolder.cs
+++ b/src/Microsoft.Framework.PackageManager/Restore/NuGet/NuGetPackageFolder.cs
@@ -11,15 +11,18 @@ namespace Microsoft.Framework.PackageManager.Restore.NuGet
 {
     public class NuGetPackageFolder : IPackageFeed
     {
-        private readonly IReport _report;
+        private readonly Reports _reports;
         private readonly LocalPackageRepository _repository;
+
+        public string Source { get; }
 
         public NuGetPackageFolder(
             string physicalPath,
-            IReport report)
+            Reports reports)
         {
-            _repository = new LocalPackageRepository(physicalPath, report);
-            _report = report;
+            _repository = new LocalPackageRepository(physicalPath, reports.Quiet);
+            _reports = reports;
+            Source = physicalPath;
         }
 
         public Task<IEnumerable<PackageInfo>> FindPackagesByIdAsync(string id)
@@ -33,7 +36,7 @@ namespace Microsoft.Framework.PackageManager.Restore.NuGet
 
         public async Task<Stream> OpenNuspecStreamAsync(PackageInfo package)
         {
-            return await PackageUtilities.OpenNuspecStreamFromNupkgAsync(package, OpenNupkgStreamAsync, _report);
+            return await PackageUtilities.OpenNuspecStreamFromNupkgAsync(package, OpenNupkgStreamAsync, _reports.Quiet);
         }
 
         public Task<Stream> OpenNupkgStreamAsync(PackageInfo package)

--- a/src/Microsoft.Framework.PackageManager/Restore/NuGet/NuGetv2Feed.cs
+++ b/src/Microsoft.Framework.PackageManager/Restore/NuGet/NuGetv2Feed.cs
@@ -33,6 +33,8 @@ namespace Microsoft.Framework.PackageManager.Restore.NuGet
         private readonly Dictionary<string, Task<IEnumerable<PackageInfo>>> _packageVersionsCache = new Dictionary<string, Task<IEnumerable<PackageInfo>>>();
         private readonly Dictionary<string, Task<NupkgEntry>> _nupkgCache = new Dictionary<string, Task<NupkgEntry>>();
 
+        public string Source { get; }
+
         public NuGetv2Feed(
             string baseUri,
             string userName,
@@ -55,6 +57,7 @@ namespace Microsoft.Framework.PackageManager.Restore.NuGet
                 _cacheAgeLimitList = TimeSpan.FromMinutes(30);
                 _cacheAgeLimitNupkg = TimeSpan.FromHours(24);
             }
+            Source = baseUri;
         }
 
         public Task<IEnumerable<PackageInfo>> FindPackagesByIdAsync(string id)

--- a/src/Microsoft.Framework.PackageManager/Restore/NuGet/PackageFolderFactory.cs
+++ b/src/Microsoft.Framework.PackageManager/Restore/NuGet/PackageFolderFactory.cs
@@ -11,19 +11,21 @@ namespace Microsoft.Framework.PackageManager
 {
     internal static class PackageFolderFactory
     {
-        public static IPackageFeed CreatePackageFolderFromPath(string path, IReport report)
+        public static IPackageFeed CreatePackageFolderFromPath(string path, bool ignoreFailedSources, Reports reports)
         {
-            Func<string, bool> containsNupkg = dir => Directory.EnumerateFiles(dir, "*" + Constants.PackageExtension)
+            Func<string, bool> containsNupkg = dir => Directory.Exists(dir) &&
+                Directory.EnumerateFiles(dir, "*" + Constants.PackageExtension)
                 .Where(x => !Path.GetFileNameWithoutExtension(x).EndsWith(".symbols"))
                 .Any();
 
-            if (containsNupkg(path) || Directory.EnumerateDirectories(path).Any(x => containsNupkg(x)))
+            if (Directory.Exists(path) &&
+                (containsNupkg(path) || Directory.EnumerateDirectories(path).Any(x => containsNupkg(x))))
             {
-                return new NuGetPackageFolder(path, report);
+                return new NuGetPackageFolder(path, reports);
             }
             else
             {
-                return new KpmPackageFolder(path, report);
+                return new KpmPackageFolder(path, ignoreFailedSources, reports);
             }
         }
     }

--- a/src/Microsoft.Framework.PackageManager/Restore/RemoteWalkProvider.cs
+++ b/src/Microsoft.Framework.PackageManager/Restore/RemoteWalkProvider.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -16,10 +17,10 @@ namespace Microsoft.Framework.PackageManager
     {
         private readonly IPackageFeed _source;
 
-        public RemoteWalkProvider(IPackageFeed source, bool isHttp)
+        public RemoteWalkProvider(IPackageFeed source)
         {
             _source = source;
-            IsHttp = isHttp;
+            IsHttp = IsHttpSource(source);
         }
 
         public bool IsHttp { get; private set; }
@@ -86,6 +87,12 @@ namespace Microsoft.Framework.PackageManager
             {
                 await nupkgStream.CopyToAsync(stream);
             }
+        }
+
+        private static bool IsHttpSource(IPackageFeed source)
+        {
+            return source.Source.StartsWith("http://", StringComparison.OrdinalIgnoreCase) ||
+                source.Source.StartsWith("https://", StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/src/Microsoft.Framework.PackageManager/Restore/RestoreCommand.cs
+++ b/src/Microsoft.Framework.PackageManager/Restore/RestoreCommand.cs
@@ -460,27 +460,10 @@ namespace Microsoft.Framework.PackageManager
         {
             foreach (var source in effectiveSources)
             {
-                if (new Uri(source.Source).IsFile)
+                var feed = PackageSourceUtils.CreatePackageFeed(source, NoCache, IgnoreFailedSources, Reports);
+                if (feed != null)
                 {
-                    remoteProviders.Add(
-                        new RemoteWalkProvider(
-                            PackageFolderFactory.CreatePackageFolderFromPath(
-                                source.Source,
-                                Reports.Quiet),
-                            isHttp: false));
-                }
-                else
-                {
-                    remoteProviders.Add(
-                        new RemoteWalkProvider(
-                            new NuGetv2Feed(
-                                source.Source,
-                                source.UserName,
-                                source.Password,
-                                NoCache,
-                                Reports,
-                                ignoreFailure: IgnoreFailedSources),
-                            isHttp: true));
+                    remoteProviders.Add(new RemoteWalkProvider(feed));
                 }
             }
         }

--- a/src/Microsoft.Framework.PackageManager/Utils/PackageSourceUtils.cs
+++ b/src/Microsoft.Framework.PackageManager/Utils/PackageSourceUtils.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using NuGet;
+using Microsoft.Framework.PackageManager.Restore.NuGet;
 
 namespace Microsoft.Framework.PackageManager
 {
@@ -23,6 +24,25 @@ namespace Microsoft.Framework.PackageManager
                 value => allSources.FirstOrDefault(source => CorrectName(value, source)) ?? new PackageSource(value));
 
             return enabledSources.Concat(addedSources).Distinct().ToList();
+        }
+
+        public static IPackageFeed CreatePackageFeed(PackageSource source, bool noCache, bool ignoreFailedSources,
+            Reports reports)
+        {
+            if (new Uri(source.Source).IsFile)
+            {
+                return PackageFolderFactory.CreatePackageFolderFromPath(source.Source, ignoreFailedSources, reports);
+            }
+            else
+            {
+                return new NuGetv2Feed(
+                    source.Source,
+                    source.UserName,
+                    source.Password,
+                    noCache,
+                    reports,
+                    ignoreFailedSources);
+            }
         }
 
         private static bool CorrectName(string value, PackageSource source)


### PR DESCRIPTION
parent #845 

`kpm restore` gives warning instead of blowing up now.
![untitled](https://cloud.githubusercontent.com/assets/1383883/5620968/b4a821da-94e5-11e4-9067-9e6033ce997b.png)

Also extracted some shared code to have DRYer code.