### PR TITLE
Print error message when it fails to initialize CLR runtime (#750)

### DIFF
--- a/src/klr.core45/klr.core45.cpp
+++ b/src/klr.core45/klr.core45.cpp
@@ -498,7 +498,7 @@ extern "C" __declspec(dllexport) HRESULT __stdcall CallApplicationMain(PCALL_APP
     {
         wprintf_s(L"TPA      %d %S\n", wcslen(pwszTrustedPlatformAssemblies), pwszTrustedPlatformAssemblies);
         wprintf_s(L"AppPaths %S\n", wszAppPaths);
-        printf_s("Failed to create app domain (%d).\n", hr);
+        printf_s("Failed to create app domain (%x).\n", hr);
         return hr;
     }
 
@@ -513,7 +513,7 @@ extern "C" __declspec(dllexport) HRESULT __stdcall CallApplicationMain(PCALL_APP
 
     if (FAILED(hr))
     {
-        printf_s("Failed to create main delegate (%d).\n", hr);
+        printf_s("Failed to create main delegate (%x).\n", hr);
         return hr;
     }
 

--- a/src/klr.net45/klr.net45.cpp
+++ b/src/klr.net45/klr.net45.cpp
@@ -8,20 +8,25 @@
 
 IKatanaManagerPtr g_katanaManager;
 
-
 extern "C" __declspec(dllexport) HRESULT __stdcall CallApplicationMain(PCALL_APPLICATION_MAIN_DATA data)
 {
     HRESULT hr = S_OK;
-    
+
     IKatanaManagerPtr manager = new ComObject<KatanaManager, IKatanaManager>();
 
     g_katanaManager = manager;
-    _HR(manager->InitializeRuntime(data->applicationBase));
-    g_katanaManager = NULL;
 
-    _HR(manager->CallApplicationMain(data->argc, data->argv));
-
-    data->exitcode = hr;
+    hr = manager->InitializeRuntime(data->applicationBase);
+    if (SUCCEEDED(hr))
+    {
+        g_katanaManager = NULL;
+        data->exitcode = manager->CallApplicationMain(data->argc, data->argv);
+    }
+    else 
+    {
+        printf_s("Failed to initalize runtime (%x)", hr);
+        data->exitcode = hr;
+    }
 
     return hr;
 }


### PR DESCRIPTION
Addressing issue #750 

After the fixing the output is:
```
C:\Users\trdai>klr
Failed to initialize runtime (-2147467263).
```
