### PR TITLE
Part 1 of better embedded reference handling

### DIFF
--- a/src/Microsoft.Framework.Runtime.Roslyn/ResourceExtensions.cs
+++ b/src/Microsoft.Framework.Runtime.Roslyn/ResourceExtensions.cs
@@ -13,10 +13,10 @@ namespace Microsoft.Framework.Runtime.Roslyn
         {
             foreach (var reference in references)
             {
-                resources.Add(new ResourceDescription(reference.Name + ".dll", () =>
+                resources.Add(new ResourceDescription("AssemblyNeutral/" + reference.Name + ".dll", () =>
                 {
                     return new MemoryStream(reference.Contents);
-                }, 
+                },
                 isPublic: true));
             }
         }

--- a/src/klr.hosting.shared/RuntimeBootstrapper.cs
+++ b/src/klr.hosting.shared/RuntimeBootstrapper.cs
@@ -322,6 +322,7 @@ namespace klr.hosting
             // Embedded assemblies end with .dll
             foreach (var name in assembly.GetManifestResourceNames())
             {
+                // TODO: Filter on AssemblyNeutral/
                 if (name.EndsWith(".dll"))
                 {
                     var assemblyName = Path.GetFileNameWithoutExtension(name);
@@ -336,7 +337,7 @@ namespace klr.hosting
 
                     var neutralAssembly = load(neutralAssemblyStream);
 
-                    _assemblyCache[assemblyName] = neutralAssembly;
+                    _assemblyCache[neutralAssembly.GetName().Name] = neutralAssembly;
                 }
             }
         }


### PR DESCRIPTION
- Embed assembly neutral interfaces as AssemblyNeutral/{name}.dll
- When harvesting embedded references from an dll on disk, first,
check to see if it's managed (handling BadImageFormatException as well).
- Use the assembly name from the manifest instead of the resource name.
- Part 2 will be to only look at AssemblyNeutral/{name}.dll when scanning for
references and loading. This should reduce the overall conflicts with existing
assemblies that use the same trick.

#973