### PR TITLE
Initial plumbing for version ranges

### DIFF
--- a/src/Microsoft.Framework.DesignTimeHost/ApplicationContext.cs
+++ b/src/Microsoft.Framework.DesignTimeHost/ApplicationContext.cs
@@ -978,13 +978,13 @@ namespace Microsoft.Framework.DesignTimeHost
             return new DependencyDescription
             {
                 Name = library.Identity.Name,
-                Version = library.Identity.Version == null ? null : library.Identity.Version.ToString(),
+                Version = library.Identity.Version?.ToString(),
                 Type = library.Resolved ? library.Type : "Unresolved",
                 Path = library.Path,
-                Dependencies = library.Dependencies.Select(lib => new DependencyItem
+                Dependencies = library.Dependencies.Select(dependency => new DependencyItem
                 {
-                    Name = lib.Name,
-                    Version = lib.Version == null ? null : lib.Version.ToString()
+                    Name = dependency.Name,
+                    Version = dependency.Library?.Version?.ToString()
                 })
             };
         }

--- a/src/Microsoft.Framework.PackageManager/Building/BuildContext.cs
+++ b/src/Microsoft.Framework.PackageManager/Building/BuildContext.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.Versioning;
@@ -105,7 +106,7 @@ namespace Microsoft.Framework.PackageManager
                 {
                     IVersionSpec dependencyVersion = null;
 
-                    if (dependency.LibraryRange == null ||
+                    if (dependency.LibraryRange.VersionRange == null ||
                         dependency.LibraryRange.VersionRange.VersionFloatBehavior != SemanticVersionFloatBehavior.None)
                     {
                         var actual = _applicationHostContext.DependencyWalker.Libraries

--- a/src/Microsoft.Framework.PackageManager/Building/BuildContext.cs
+++ b/src/Microsoft.Framework.PackageManager/Building/BuildContext.cs
@@ -97,15 +97,16 @@ namespace Microsoft.Framework.PackageManager
                     continue;
                 }
 
-                if (dependency.Library.IsGacOrFrameworkReference)
+                if (dependency.LibraryRange.IsGacOrFrameworkReference)
                 {
                     packageBuilder.FrameworkReferences.Add(new FrameworkAssemblyReference(dependency.Name, new[] { _targetFramework }));
                 }
                 else
                 {
-                    var dependencyVersion = dependency.Library.RequestedVersion;
+                    IVersionSpec dependencyVersion = null;
 
-                    if (dependencyVersion == null || dependencyVersion.IsSnapshot)
+                    if (dependency.LibraryRange == null ||
+                        dependency.LibraryRange.VersionRange.VersionFloatBehavior != SemanticVersionFloatBehavior.None)
                     {
                         var actual = _applicationHostContext.DependencyWalker.Libraries
                             .Where(pkg => string.Equals(pkg.Identity.Name, _project.Name, StringComparison.OrdinalIgnoreCase))
@@ -118,9 +119,21 @@ namespace Microsoft.Framework.PackageManager
                             dependencyVersion = new VersionSpec
                             {
                                 IsMinInclusive = true,
-                                MinVersion = actual.Version
+                                MinVersion = actual.Library.Version
                             };
                         }
+                    }
+                    else
+                    {
+                        var versionRange = dependency.LibraryRange.VersionRange;
+
+                        dependencyVersion = new VersionSpec
+                        {
+                            IsMinInclusive = true,
+                            MinVersion = versionRange.MinVersion,
+                            MaxVersion = versionRange.MaxVersion,
+                            IsMaxInclusive = versionRange.IsMaxInclusive
+                        };
                     }
 
                     dependencies.Add(new PackageDependency(dependency.Name, dependencyVersion));

--- a/src/Microsoft.Framework.PackageManager/Building/BuildContext.cs
+++ b/src/Microsoft.Framework.PackageManager/Building/BuildContext.cs
@@ -103,22 +103,23 @@ namespace Microsoft.Framework.PackageManager
                 }
                 else
                 {
-                    var dependencyVersion = new VersionSpec()
-                    {
-                        IsMinInclusive = true,
-                        MinVersion = dependency.Version
-                    };
+                    var dependencyVersion = dependency.Library.RequestedVersion;
 
-                    if (dependencyVersion.MinVersion == null || dependencyVersion.MinVersion.IsSnapshot)
+                    if (dependencyVersion == null || dependencyVersion.IsSnapshot)
                     {
                         var actual = _applicationHostContext.DependencyWalker.Libraries
                             .Where(pkg => string.Equals(pkg.Identity.Name, _project.Name, StringComparison.OrdinalIgnoreCase))
                             .SelectMany(pkg => pkg.Dependencies)
                             .SingleOrDefault(dep => string.Equals(dep.Name, dependency.Name, StringComparison.OrdinalIgnoreCase));
 
+
                         if (actual != null)
                         {
-                            dependencyVersion.MinVersion = actual.Version;
+                            dependencyVersion = new VersionSpec
+                            {
+                                IsMinInclusive = true,
+                                MinVersion = actual.Version
+                            };
                         }
                     }
 

--- a/src/Microsoft.Framework.PackageManager/Commands/InstallCommand.cs
+++ b/src/Microsoft.Framework.PackageManager/Commands/InstallCommand.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Framework.PackageManager
             }
             else
             {
-                result = await FindBestMatch(packageFeeds, _addCommand.Name, new VersionSpec(version));
+                result = await FindBestMatch(packageFeeds, _addCommand.Name, new SemanticVersionRange(version));
             }
 
             if (result == null)
@@ -121,7 +121,7 @@ namespace Microsoft.Framework.PackageManager
         }
 
         private static async Task<PackageInfo> FindBestMatch(IEnumerable<IPackageFeed> packageFeeds, string packageName,
-            IVersionSpec idealVersion)
+            SemanticVersionRange idealVersion)
         {
             var tasks = new List<Task<IEnumerable<PackageInfo>>>();
 

--- a/src/Microsoft.Framework.PackageManager/Restore/GraphModel/GraphNode.cs
+++ b/src/Microsoft.Framework.PackageManager/Restore/GraphModel/GraphNode.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Framework.PackageManager
             Dependencies = new List<GraphNode>();
         }
 
-        public Library Library { get; set; }
+        public LibraryRange LibraryRange { get; set; }
         public List<GraphNode> Dependencies { get; private set; }
         public GraphItem Item { get; set; }
     }

--- a/src/Microsoft.Framework.PackageManager/Restore/IWalkProvider.cs
+++ b/src/Microsoft.Framework.PackageManager/Restore/IWalkProvider.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Framework.PackageManager
     {
         bool IsHttp { get; }
 
-        Task<WalkProviderMatch> FindLibraryByVersion(Library library, FrameworkName targetFramework);
+        Task<WalkProviderMatch> FindLibrary(Library library, FrameworkName targetFramework);
         Task<IEnumerable<LibraryDependency>> GetDependencies(WalkProviderMatch match, FrameworkName targetFramework);
         Task CopyToAsync(WalkProviderMatch match, Stream stream);
     }

--- a/src/Microsoft.Framework.PackageManager/Restore/IWalkProvider.cs
+++ b/src/Microsoft.Framework.PackageManager/Restore/IWalkProvider.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Framework.PackageManager
     {
         bool IsHttp { get; }
 
-        Task<WalkProviderMatch> FindLibrary(Library library, FrameworkName targetFramework);
+        Task<WalkProviderMatch> FindLibrary(LibraryRange libraryRange, FrameworkName targetFramework);
         Task<IEnumerable<LibraryDependency>> GetDependencies(WalkProviderMatch match, FrameworkName targetFramework);
         Task CopyToAsync(WalkProviderMatch match, Stream stream);
     }

--- a/src/Microsoft.Framework.PackageManager/Restore/LocalWalkProvider.cs
+++ b/src/Microsoft.Framework.PackageManager/Restore/LocalWalkProvider.cs
@@ -22,9 +22,10 @@ namespace Microsoft.Framework.PackageManager
 
         public bool IsHttp { get; private set; }
 
-        public Task<WalkProviderMatch> FindLibrary(Library library, FrameworkName targetFramework)
+        public Task<WalkProviderMatch> FindLibrary(LibraryRange libraryRange, FrameworkName targetFramework)
         {
-            var description = _dependencyProvider.GetDescription(library, targetFramework);
+            var description = _dependencyProvider.GetDescription(libraryRange, targetFramework);
+
             if (description == null)
             {
                 return Task.FromResult<WalkProviderMatch>(null);
@@ -41,6 +42,7 @@ namespace Microsoft.Framework.PackageManager
         public Task<IEnumerable<LibraryDependency>> GetDependencies(WalkProviderMatch match, FrameworkName targetFramework)
         {
             var description = _dependencyProvider.GetDescription(match.Library, targetFramework);
+
             return Task.FromResult(description.Dependencies);
         }
 

--- a/src/Microsoft.Framework.PackageManager/Restore/LocalWalkProvider.cs
+++ b/src/Microsoft.Framework.PackageManager/Restore/LocalWalkProvider.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Framework.PackageManager
 
         public bool IsHttp { get; private set; }
 
-        public Task<WalkProviderMatch> FindLibraryByVersion(Library library, FrameworkName targetFramework)
+        public Task<WalkProviderMatch> FindLibrary(Library library, FrameworkName targetFramework)
         {
             var description = _dependencyProvider.GetDescription(library, targetFramework);
             if (description == null)

--- a/src/Microsoft.Framework.PackageManager/Restore/RestoreContext.cs
+++ b/src/Microsoft.Framework.PackageManager/Restore/RestoreContext.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Framework.PackageManager
     {
         public RestoreContext()
         {
-            FindLibraryCache = new Dictionary<Library, Task<GraphItem>>();
+            FindLibraryCache = new Dictionary<LibraryRange, Task<GraphItem>>();
         }
 
         public FrameworkName FrameworkName { get; set; }
@@ -21,6 +21,6 @@ namespace Microsoft.Framework.PackageManager
         public IList<IWalkProvider> LocalLibraryProviders { get; set; }
         public IList<IWalkProvider> RemoteLibraryProviders { get; set; }
 
-        public Dictionary<Library, Task<GraphItem>> FindLibraryCache { get; private set; }
+        public Dictionary<LibraryRange, Task<GraphItem>> FindLibraryCache { get; private set; }
     }
 }

--- a/src/Microsoft.Framework.Runtime/DependencyManagement/GacDependencyResolver.cs
+++ b/src/Microsoft.Framework.Runtime/DependencyManagement/GacDependencyResolver.cs
@@ -30,9 +30,9 @@ namespace Microsoft.Framework.Runtime
             return GetGacSearchPaths().Select(p => Path.Combine(p, "{name}", "{version}", "{name}.dll"));
         }
 
-        public LibraryDescription GetDescription(Library library, FrameworkName targetFramework)
+        public LibraryDescription GetDescription(LibraryRange libraryRange, FrameworkName targetFramework)
         {
-            if (!library.IsGacOrFrameworkReference)
+            if (!libraryRange.IsGacOrFrameworkReference)
             {
                 return null;
             }
@@ -47,8 +47,8 @@ namespace Microsoft.Framework.Runtime
                 return null;
             }
 
-            var name = library.Name;
-            var version = library.RequestedVersion?.MinVersion;
+            var name = libraryRange.Name;
+            var version = libraryRange.VersionRange?.MinVersion;
 
             string path;
             if (!TryResolvePartialName(name, out path))
@@ -64,11 +64,11 @@ namespace Microsoft.Framework.Runtime
 
                 return new LibraryDescription
                 {
+                    LibraryRange = libraryRange,
                     Identity = new Library
                     {
                         Name = name,
                         Version = assemblyVersion,
-                        RequestedVersion = library.RequestedVersion,
                         IsGacOrFrameworkReference = true
                     },
                     LoadableAssemblies = new[] { name },

--- a/src/Microsoft.Framework.Runtime/DependencyManagement/GacDependencyResolver.cs
+++ b/src/Microsoft.Framework.Runtime/DependencyManagement/GacDependencyResolver.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Framework.Runtime
             }
 
             var name = library.Name;
-            var version = library.Version;
+            var version = library.RequestedVersion?.MinVersion;
 
             string path;
             if (!TryResolvePartialName(name, out path))
@@ -68,6 +68,7 @@ namespace Microsoft.Framework.Runtime
                     {
                         Name = name,
                         Version = assemblyVersion,
+                        RequestedVersion = library.RequestedVersion,
                         IsGacOrFrameworkReference = true
                     },
                     LoadableAssemblies = new[] { name },

--- a/src/Microsoft.Framework.Runtime/DependencyManagement/IDependencyProvider.cs
+++ b/src/Microsoft.Framework.Runtime/DependencyManagement/IDependencyProvider.cs
@@ -3,13 +3,12 @@
 
 using System.Collections.Generic;
 using System.Runtime.Versioning;
-using NuGet;
 
 namespace Microsoft.Framework.Runtime
 {
     public interface IDependencyProvider
     {
-        LibraryDescription GetDescription(Library library, FrameworkName targetFramework);
+        LibraryDescription GetDescription(LibraryRange libraryRange, FrameworkName targetFramework);
 
         void Initialize(IEnumerable<LibraryDescription> dependencies, FrameworkName targetFramework);
 

--- a/src/Microsoft.Framework.Runtime/DependencyManagement/LibraryDependency.cs
+++ b/src/Microsoft.Framework.Runtime/DependencyManagement/LibraryDependency.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Framework.Runtime
     {
         public LibraryRange LibraryRange { get; set; }
 
-        public LibraryDependencyType Type { get; set; }
+        public LibraryDependencyType Type { get; set; } = LibraryDependencyType.Default;
 
         public Library Library { get; set; }
 

--- a/src/Microsoft.Framework.Runtime/DependencyManagement/LibraryDependency.cs
+++ b/src/Microsoft.Framework.Runtime/DependencyManagement/LibraryDependency.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Text;
 using NuGet;
 
 namespace Microsoft.Framework.Runtime
@@ -23,7 +24,18 @@ namespace Microsoft.Framework.Runtime
 
         public override string ToString()
         {
-            return (Library?.ToString() ?? LibraryRange.ToString()) + " " + Type;
+            var sb = new StringBuilder();
+            sb.Append(LibraryRange);
+            sb.Append(" ");
+
+            if (Library != null)
+            {
+                sb.Append("(" + Library + ")");
+                sb.Append(" ");
+            }
+
+            sb.Append(Type);
+            return sb.ToString();
         }
 
         public bool HasFlag(LibraryDependencyTypeFlag flag)

--- a/src/Microsoft.Framework.Runtime/DependencyManagement/LibraryDependency.cs
+++ b/src/Microsoft.Framework.Runtime/DependencyManagement/LibraryDependency.cs
@@ -2,114 +2,28 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using NuGet;
-using System;
 
 namespace Microsoft.Framework.Runtime
 {
-    /// <summary>
-    /// Summary description for LibraryDescriptor
-    /// </summary>
     public class LibraryDependency
     {
-        public LibraryDependency(
-            string name) : this(
-                new Library
-                {
-                    Name = name
-                },
-                LibraryDependencyType.Default)
-        {
-        }
+        public LibraryRange LibraryRange { get; set; }
 
-        public LibraryDependency(
-            string name,
-            bool isGacOrFrameworkReference) : this(
-                new Library
-                {
-                    Name = name,
-                    IsGacOrFrameworkReference = isGacOrFrameworkReference
-                },
-                LibraryDependencyType.Default)
-        {
-        }
-
-        public LibraryDependency(
-            string name,
-            SemanticVersion version) : this(
-                new Library
-                {
-                    Name = name,
-                    Version = version
-                },
-                LibraryDependencyType.Default)
-        {
-        }
-
-        public LibraryDependency(
-            string name,
-            SemanticVersion version,
-            bool isGacOrFrameworkReference,
-            LibraryDependencyType type) : this(
-                new Library
-                {
-                    Name = name,
-                    Version = version,
-                    IsGacOrFrameworkReference = isGacOrFrameworkReference
-                },
-                type)
-        {
-        }
-
-        public LibraryDependency(
-            Library library) : this(
-                library,
-                LibraryDependencyType.Default)
-        {
-        }
-
-        public LibraryDependency(
-            Library library,
-            LibraryDependencyType type)
-        {
-            Library = library;
-            Type = type;
-        }
+        public LibraryDependencyType Type { get; set; }
 
         public Library Library { get; set; }
 
         public string Name
         {
-            get { return Library.Name; }
+            get
+            {
+                return LibraryRange.Name;
+            }
         }
-
-        public SemanticVersion Version
-        {
-            get { return Library.Version; }
-        }
-
-        public bool IsGacOrFrameworkReference
-        {
-            get { return Library.IsGacOrFrameworkReference; }
-        }
-
-        public LibraryDependencyType Type { get; private set; }
 
         public override string ToString()
         {
-            return string.Format("{0} {1}", Library, Type);
-        }
-
-        public LibraryDependency ChangeVersion(SemanticVersion version)
-        {
-            var library = new Library
-            {
-                Name = Library.Name,
-                Version = version,
-                RequestedVersion = Library.RequestedVersion,
-                IsGacOrFrameworkReference = Library.IsGacOrFrameworkReference,
-            };
-
-            return new LibraryDependency(library, Type);
+            return (Library?.ToString() ?? LibraryRange.ToString()) + " " + Type;
         }
 
         public bool HasFlag(LibraryDependencyTypeFlag flag)

--- a/src/Microsoft.Framework.Runtime/DependencyManagement/LibraryDependency.cs
+++ b/src/Microsoft.Framework.Runtime/DependencyManagement/LibraryDependency.cs
@@ -101,11 +101,15 @@ namespace Microsoft.Framework.Runtime
 
         public LibraryDependency ChangeVersion(SemanticVersion version)
         {
-            return new LibraryDependency(
-                name: Library.Name,
-                version: version,
-                isGacOrFrameworkReference: Library.IsGacOrFrameworkReference,
-                type: Type);
+            var library = new Library
+            {
+                Name = Library.Name,
+                Version = version,
+                RequestedVersion = Library.RequestedVersion,
+                IsGacOrFrameworkReference = Library.IsGacOrFrameworkReference,
+            };
+
+            return new LibraryDependency(library, Type);
         }
 
         public bool HasFlag(LibraryDependencyTypeFlag flag)

--- a/src/Microsoft.Framework.Runtime/DependencyManagement/LibraryDescription.cs
+++ b/src/Microsoft.Framework.Runtime/DependencyManagement/LibraryDescription.cs
@@ -8,12 +8,15 @@ namespace Microsoft.Framework.Runtime
 {
     public class LibraryDescription
     {
+        public LibraryRange LibraryRange { get; set; }
         public Library Identity { get; set; }
+        public IEnumerable<LibraryDependency> Dependencies { get; set; }
+
+        public bool Resolved { get; set; } = true;
+
         public string Path { get; set; }
         public string Type { get; set; }
         public FrameworkName Framework { get; set; }
-        public IEnumerable<LibraryDependency> Dependencies { get; set; }
         public IEnumerable<string> LoadableAssemblies { get; set; }
-        public bool Resolved { get; set; } = true;
     }
 }

--- a/src/Microsoft.Framework.Runtime/DependencyManagement/LibraryRange.cs
+++ b/src/Microsoft.Framework.Runtime/DependencyManagement/LibraryRange.cs
@@ -1,31 +1,27 @@
-// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
-
-using System;
-using NuGet;
+﻿using System;
 
 namespace Microsoft.Framework.Runtime
 {
-    public class Library : IEquatable<Library>
+    public class LibraryRange : IEquatable<LibraryRange>
     {
         public string Name { get; set; }
 
-        public SemanticVersion Version { get; set; }
+        public SemanticVersionRange VersionRange { get; set; }
 
         public bool IsGacOrFrameworkReference { get; set; }
 
         public override string ToString()
         {
             var name = IsGacOrFrameworkReference ? "framework/" + Name : Name;
-            return name + " " + Version?.ToString();
+            return name + " " + (VersionRange?.ToString());
         }
 
-        public bool Equals(Library other)
+        public bool Equals(LibraryRange other)
         {
             if (ReferenceEquals(null, other)) return false;
             if (ReferenceEquals(this, other)) return true;
             return string.Equals(Name, other.Name) &&
-                Equals(Version, other.Version) &&
+                Equals(VersionRange, other.VersionRange) &&
                 Equals(IsGacOrFrameworkReference, other.IsGacOrFrameworkReference);
         }
 
@@ -34,7 +30,7 @@ namespace Microsoft.Framework.Runtime
             if (ReferenceEquals(null, obj)) return false;
             if (ReferenceEquals(this, obj)) return true;
             if (obj.GetType() != this.GetType()) return false;
-            return Equals((Library)obj);
+            return Equals((LibraryRange)obj);
         }
 
         public override int GetHashCode()
@@ -42,32 +38,19 @@ namespace Microsoft.Framework.Runtime
             unchecked
             {
                 return ((Name != null ? Name.GetHashCode() : 0) * 397) ^
-                    (Version != null ? Version.GetHashCode() : 0) ^
+                    (VersionRange != null ? VersionRange.GetHashCode() : 0) ^
                     (IsGacOrFrameworkReference.GetHashCode());
             }
         }
 
-        public static bool operator ==(Library left, Library right)
+        public static bool operator ==(LibraryRange left, LibraryRange right)
         {
             return Equals(left, right);
         }
 
-        public static bool operator !=(Library left, Library right)
+        public static bool operator !=(LibraryRange left, LibraryRange right)
         {
             return !Equals(left, right);
-        }
-
-        public static implicit operator LibraryRange(Library library)
-        {
-            return new LibraryRange
-            {
-                Name = library.Name,
-                VersionRange = new SemanticVersionRange
-                {
-                    MinVersion = library.Version,
-                    VersionFloatBehavior = SemanticVersionFloatBehavior.None
-                }
-            };
         }
     }
 }

--- a/src/Microsoft.Framework.Runtime/DependencyManagement/ProjectReferenceDependencyProvider.cs
+++ b/src/Microsoft.Framework.Runtime/DependencyManagement/ProjectReferenceDependencyProvider.cs
@@ -34,7 +34,6 @@ namespace Microsoft.Framework.Runtime
             }
 
             var name = library.Name;
-            var version = library.Version;
 
             Project project;
 
@@ -86,6 +85,7 @@ namespace Microsoft.Framework.Runtime
                 Identity = new Library
                 {
                     Name = project.Name,
+                    RequestedVersion = library.RequestedVersion,
                     Version = project.Version
                 },
                 Type = "Project",

--- a/src/Microsoft.Framework.Runtime/DependencyManagement/ProjectReferenceDependencyProvider.cs
+++ b/src/Microsoft.Framework.Runtime/DependencyManagement/ProjectReferenceDependencyProvider.cs
@@ -26,14 +26,14 @@ namespace Microsoft.Framework.Runtime
             return _projectResolver.SearchPaths.Select(p => Path.Combine(p, "{name}", "project.json"));
         }
 
-        public LibraryDescription GetDescription(Library library, FrameworkName targetFramework)
+        public LibraryDescription GetDescription(LibraryRange libraryRange, FrameworkName targetFramework)
         {
-            if (library.IsGacOrFrameworkReference)
+            if (libraryRange.IsGacOrFrameworkReference)
             {
                 return null;
             }
 
-            var name = library.Name;
+            string name = libraryRange.Name;
 
             Project project;
 
@@ -49,21 +49,41 @@ namespace Microsoft.Framework.Runtime
 
             if (VersionUtility.IsDesktop(targetFramework))
             {
-                targetFrameworkDependencies.Add(new LibraryDependency(
-                    name: "mscorlib",
-                    isGacOrFrameworkReference: true));
+                targetFrameworkDependencies.Add(new LibraryDependency
+                {
+                    LibraryRange = new LibraryRange
+                    {
+                        Name = "mscorlib",
+                        IsGacOrFrameworkReference = true
+                    }
+                });
 
-                targetFrameworkDependencies.Add(new LibraryDependency(
-                    name: "System",
-                    isGacOrFrameworkReference: true));
+                targetFrameworkDependencies.Add(new LibraryDependency
+                {
+                    LibraryRange = new LibraryRange
+                    {
+                        Name = "System",
+                        IsGacOrFrameworkReference = true
+                    }
+                });
 
-                targetFrameworkDependencies.Add(new LibraryDependency(
-                    name: "System.Core",
-                    isGacOrFrameworkReference: true));
+                targetFrameworkDependencies.Add(new LibraryDependency
+                {
+                    LibraryRange = new LibraryRange
+                    {
+                        Name = "System.Core",
+                        IsGacOrFrameworkReference = true
+                    }
+                });
 
-                targetFrameworkDependencies.Add(new LibraryDependency(
-                    name: "Microsoft.CSharp",
-                    isGacOrFrameworkReference: true));
+                targetFrameworkDependencies.Add(new LibraryDependency
+                {
+                    LibraryRange = new LibraryRange
+                    {
+                        Name = "Microsoft.CSharp",
+                        IsGacOrFrameworkReference = true
+                    }
+                });
             }
 
             var dependencies = project.Dependencies.Concat(targetFrameworkDependencies).ToList();
@@ -82,10 +102,10 @@ namespace Microsoft.Framework.Runtime
 
             return new LibraryDescription
             {
+                LibraryRange = libraryRange,
                 Identity = new Library
                 {
                     Name = project.Name,
-                    RequestedVersion = library.RequestedVersion,
                     Version = project.Version
                 },
                 Type = "Project",

--- a/src/Microsoft.Framework.Runtime/DependencyManagement/ReferenceAssemblyDependencyResolver.cs
+++ b/src/Microsoft.Framework.Runtime/DependencyManagement/ReferenceAssemblyDependencyResolver.cs
@@ -36,15 +36,15 @@ namespace Microsoft.Framework.Runtime
             return Enumerable.Empty<string>();
         }
 
-        public LibraryDescription GetDescription(Library library, FrameworkName targetFramework)
+        public LibraryDescription GetDescription(LibraryRange libraryRange, FrameworkName targetFramework)
         {
-            if (!library.IsGacOrFrameworkReference)
+            if (!libraryRange.IsGacOrFrameworkReference)
             {
                 return null;
             }
 
-            var name = library.Name;
-            var version = library.RequestedVersion?.MinVersion;
+            var name = libraryRange.Name;
+            var version = libraryRange.VersionRange?.MinVersion;
 
             string path;
             if (!FrameworkResolver.TryGetAssembly(name, targetFramework, out path))
@@ -60,11 +60,11 @@ namespace Microsoft.Framework.Runtime
 
                 return new LibraryDescription
                 {
+                    LibraryRange = libraryRange,
                     Identity = new Library
                     {
                         Name = name,
                         Version = assemblyVersion,
-                        RequestedVersion = library.RequestedVersion,
                         IsGacOrFrameworkReference = true
                     },
                     LoadableAssemblies = new[] { name },

--- a/src/Microsoft.Framework.Runtime/DependencyManagement/ReferenceAssemblyDependencyResolver.cs
+++ b/src/Microsoft.Framework.Runtime/DependencyManagement/ReferenceAssemblyDependencyResolver.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Framework.Runtime
             }
 
             var name = library.Name;
-            var version = library.Version;
+            var version = library.RequestedVersion?.MinVersion;
 
             string path;
             if (!FrameworkResolver.TryGetAssembly(name, targetFramework, out path))
@@ -64,6 +64,7 @@ namespace Microsoft.Framework.Runtime
                     {
                         Name = name,
                         Version = assemblyVersion,
+                        RequestedVersion = library.RequestedVersion,
                         IsGacOrFrameworkReference = true
                     },
                     LoadableAssemblies = new[] { name },

--- a/src/Microsoft.Framework.Runtime/DependencyManagement/SemanticVersionFloatBehavior.cs
+++ b/src/Microsoft.Framework.Runtime/DependencyManagement/SemanticVersionFloatBehavior.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace Microsoft.Framework.Runtime
+{
+    public enum SemanticVersionFloatBehavior
+    {
+        None,
+        Prerelease,
+        Revision,
+        Build,
+        Minor,
+        Major
+    }
+
+}

--- a/src/Microsoft.Framework.Runtime/DependencyManagement/SemanticVersionRange.cs
+++ b/src/Microsoft.Framework.Runtime/DependencyManagement/SemanticVersionRange.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using NuGet;
+
+namespace Microsoft.Framework.Runtime
+{
+    public class SemanticVersionRange : IEquatable<SemanticVersionRange>
+    {
+        public SemanticVersionRange()
+        {
+        }
+
+        public SemanticVersionRange(IVersionSpec versionSpec)
+        {
+            MinVersion = versionSpec.MinVersion;
+            MaxVersion = versionSpec.MaxVersion;
+            VersionFloatBehavior = SemanticVersionFloatBehavior.None;
+        }
+
+        public SemanticVersionRange(SemanticVersion version)
+        {
+            MinVersion = version;
+            VersionFloatBehavior = SemanticVersionFloatBehavior.None;
+        }
+
+        public SemanticVersion MinVersion { get; set; }
+        public SemanticVersion MaxVersion { get; set; }
+        public SemanticVersionFloatBehavior VersionFloatBehavior { get; set; }
+        public bool IsMaxInclusive { get; set; }
+
+        public bool Equals(SemanticVersionRange other)
+        {
+            if (ReferenceEquals(null, other)) return false;
+            if (ReferenceEquals(this, other)) return true;
+            return Equals(MinVersion, other.MinVersion) &&
+                Equals(MaxVersion, other.MaxVersion) &&
+                Equals(VersionFloatBehavior, other.VersionFloatBehavior) &&
+                Equals(IsMaxInclusive, other.IsMaxInclusive);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((SemanticVersionRange)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            int hashCode = MinVersion.GetHashCode();
+
+            hashCode = CombineHashCode(hashCode, VersionFloatBehavior.GetHashCode());
+
+            if (MaxVersion != null)
+            {
+                hashCode = CombineHashCode(hashCode, MaxVersion.GetHashCode());
+            }
+
+            hashCode = CombineHashCode(hashCode, IsMaxInclusive.GetHashCode());
+
+            return hashCode;
+        }
+
+        private static int CombineHashCode(int h1, int h2)
+        {
+            return h1 * 4567 + h2;
+        }
+    }
+}

--- a/src/Microsoft.Framework.Runtime/DependencyManagement/SemanticVersionRange.cs
+++ b/src/Microsoft.Framework.Runtime/DependencyManagement/SemanticVersionRange.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Text;
 using NuGet;
 
 namespace Microsoft.Framework.Runtime
@@ -26,6 +27,49 @@ namespace Microsoft.Framework.Runtime
         public SemanticVersion MaxVersion { get; set; }
         public SemanticVersionFloatBehavior VersionFloatBehavior { get; set; }
         public bool IsMaxInclusive { get; set; }
+
+        public override string ToString()
+        {
+            var sb = new StringBuilder();
+            sb.Append(">= ");
+            switch (VersionFloatBehavior)
+            {
+                case SemanticVersionFloatBehavior.None:
+                    sb.Append(MinVersion);
+                    break;
+                case SemanticVersionFloatBehavior.Prerelease:
+                    sb.AppendFormat("{0}-*", MinVersion);
+                    break;
+                case SemanticVersionFloatBehavior.Revision:
+                    sb.AppendFormat("{0}.{1}.{2}.*",
+                        MinVersion.Version.Major,
+                        MinVersion.Version.Minor,
+                        MinVersion.Version.Build);
+                    break;
+                case SemanticVersionFloatBehavior.Build:
+                    sb.AppendFormat("{0}.{1}.*",
+                        MinVersion.Version.Major,
+                        MinVersion.Version.Minor);
+                    break;
+                case SemanticVersionFloatBehavior.Minor:
+                    sb.AppendFormat("{0}.{1}.*",
+                        MinVersion.Version.Major);
+                    break;
+                case SemanticVersionFloatBehavior.Major:
+                    sb.AppendFormat("*");
+                    break;
+                default:
+                    break;
+            }
+
+            if (MaxVersion != null)
+            {
+                sb.Append(IsMaxInclusive ? "<= " : "< ");
+                sb.Append(MaxVersion);
+            }
+
+            return sb.ToString();
+        }
 
         public bool Equals(SemanticVersionRange other)
         {

--- a/src/Microsoft.Framework.Runtime/DependencyManagement/UnresolvedDependencyProvider.cs
+++ b/src/Microsoft.Framework.Runtime/DependencyManagement/UnresolvedDependencyProvider.cs
@@ -9,11 +9,11 @@ namespace Microsoft.Framework.Runtime
 {
     public class UnresolvedDependencyProvider : IDependencyProvider
     {
-        public LibraryDescription GetDescription(Library library, FrameworkName targetFramework)
+        public LibraryDescription GetDescription(LibraryRange libraryRange, FrameworkName targetFramework)
         {
             return new LibraryDescription
             {
-                Identity = library,
+                LibraryRange = libraryRange,
                 Dependencies = Enumerable.Empty<LibraryDependency>(),
                 Resolved = false
             };

--- a/src/Microsoft.Framework.Runtime/DependencyManagement/UnresolvedDependencyProvider.cs
+++ b/src/Microsoft.Framework.Runtime/DependencyManagement/UnresolvedDependencyProvider.cs
@@ -14,6 +14,12 @@ namespace Microsoft.Framework.Runtime
             return new LibraryDescription
             {
                 LibraryRange = libraryRange,
+                Identity = new Library
+                {
+                    Name = libraryRange.Name,
+                    IsGacOrFrameworkReference = libraryRange.IsGacOrFrameworkReference,
+                    Version = libraryRange.VersionRange.MinVersion
+                },
                 Dependencies = Enumerable.Empty<LibraryDependency>(),
                 Resolved = false
             };

--- a/src/Microsoft.Framework.Runtime/DependencyManagement/WalkContext.cs
+++ b/src/Microsoft.Framework.Runtime/DependencyManagement/WalkContext.cs
@@ -25,7 +25,11 @@ namespace Microsoft.Framework.Runtime
         {
             var root = new Node
             {
-                Key = new Library { Name = name, Version = version }
+                Key = new Library
+                {
+                    Name = name,
+                    RequestedVersion = new VersionSpec(version)
+                }
             };
 
             var resolvers = dependencyResolvers as IDependencyProvider[] ?? dependencyResolvers.ToArray();

--- a/src/Microsoft.Framework.Runtime/NuGet/Extensions/VersionExtensions.cs
+++ b/src/Microsoft.Framework.Runtime/NuGet/Extensions/VersionExtensions.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using Microsoft.Framework.Runtime;
 
 namespace NuGet
 {
@@ -74,15 +75,36 @@ namespace NuGet
             return versionSpec.ToDelegate<SemanticVersion>(v => v)(version);
         }
 
-        public static bool EqualsSnapshot(this IVersionSpec versionSpec, SemanticVersion version)
+        public static bool EqualsFloating(this SemanticVersionRange versionRange, SemanticVersion version)
         {
-            if (versionSpec.IsSnapshot)
+            switch (versionRange.VersionFloatBehavior)
             {
-                return versionSpec.MinVersion.Version == version.Version &&
-                       version.SpecialVersion.StartsWith(versionSpec.MinVersion.SpecialVersion, StringComparison.OrdinalIgnoreCase);
-            }
+                case SemanticVersionFloatBehavior.Prerelease:
+                    return versionRange.MinVersion.Version == version.Version &&
+                           version.SpecialVersion.StartsWith(versionRange.MinVersion.SpecialVersion, StringComparison.OrdinalIgnoreCase);
 
-            return false;
+                case SemanticVersionFloatBehavior.Revision:
+                    return versionRange.MinVersion.Version.Major == version.Version.Major &&
+                           versionRange.MinVersion.Version.Minor == version.Version.Minor &&
+                           versionRange.MinVersion.Version.Build == version.Version.Build &&
+                           versionRange.MinVersion.Version.Revision == version.Version.Revision;
+
+                case SemanticVersionFloatBehavior.Build:
+                    return versionRange.MinVersion.Version.Major == version.Version.Major &&
+                           versionRange.MinVersion.Version.Minor == version.Version.Minor &&
+                           versionRange.MinVersion.Version.Build == version.Version.Build;
+
+                case SemanticVersionFloatBehavior.Minor:
+                    return versionRange.MinVersion.Version.Major == version.Version.Major &&
+                           versionRange.MinVersion.Version.Minor == version.Version.Minor;
+
+                case SemanticVersionFloatBehavior.Major:
+                    return versionRange.MinVersion.Version.Major == version.Version.Major;
+
+                case SemanticVersionFloatBehavior.None:
+                default:
+                    return false;
+            }
         }
 
         public static IEnumerable<string> GetComparableVersionStrings(this SemanticVersion version)

--- a/src/Microsoft.Framework.Runtime/NuGet/Extensions/VersionExtensions.cs
+++ b/src/Microsoft.Framework.Runtime/NuGet/Extensions/VersionExtensions.cs
@@ -102,6 +102,7 @@ namespace NuGet
                     return versionRange.MinVersion.Version.Major == version.Version.Major;
 
                 case SemanticVersionFloatBehavior.None:
+                    return versionRange.MinVersion == version;
                 default:
                     return false;
             }

--- a/src/Microsoft.Framework.Runtime/NuGet/Extensions/VersionExtensions.cs
+++ b/src/Microsoft.Framework.Runtime/NuGet/Extensions/VersionExtensions.cs
@@ -64,7 +64,7 @@ namespace NuGet
         /// <summary>
         /// Determines if the specified version is within the version spec
         /// </summary>
-        public static bool Satisfies(this IVersionSpec versionSpec, SemanticVersion version)
+        public static bool IsSatisfiedBy(this IVersionSpec versionSpec, SemanticVersion version)
         {
             // The range is unbounded so return true
             if (versionSpec == null)
@@ -72,6 +72,17 @@ namespace NuGet
                 return true;
             }
             return versionSpec.ToDelegate<SemanticVersion>(v => v)(version);
+        }
+
+        public static bool EqualsSnapshot(this IVersionSpec versionSpec, SemanticVersion version)
+        {
+            if (versionSpec.IsSnapshot)
+            {
+                return versionSpec.MinVersion.Version == version.Version &&
+                       version.SpecialVersion.StartsWith(versionSpec.MinVersion.SpecialVersion, StringComparison.OrdinalIgnoreCase);
+            }
+
+            return false;
         }
 
         public static IEnumerable<string> GetComparableVersionStrings(this SemanticVersion version)

--- a/src/Microsoft.Framework.Runtime/NuGet/Utility/IVersionSpec.cs
+++ b/src/Microsoft.Framework.Runtime/NuGet/Utility/IVersionSpec.cs
@@ -6,6 +6,7 @@ namespace NuGet
 {
     public interface IVersionSpec
     {
+        bool IsSnapshot { get; }
         SemanticVersion MinVersion { get; }
         bool IsMinInclusive { get; }
         SemanticVersion MaxVersion { get; }

--- a/src/Microsoft.Framework.Runtime/NuGet/Utility/IVersionSpec.cs
+++ b/src/Microsoft.Framework.Runtime/NuGet/Utility/IVersionSpec.cs
@@ -1,12 +1,10 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-
 namespace NuGet
 {
     public interface IVersionSpec
     {
-        bool IsSnapshot { get; }
         SemanticVersion MinVersion { get; }
         bool IsMinInclusive { get; }
         SemanticVersion MaxVersion { get; }

--- a/src/Microsoft.Framework.Runtime/NuGet/Utility/VersionSpec.cs
+++ b/src/Microsoft.Framework.Runtime/NuGet/Utility/VersionSpec.cs
@@ -15,7 +15,6 @@ namespace NuGet
 
         public VersionSpec(SemanticVersion version)
         {
-            IsSnapshot = false;
             IsMinInclusive = true;
             IsMaxInclusive = true;
             MinVersion = version;
@@ -26,15 +25,9 @@ namespace NuGet
         public bool IsMinInclusive { get; set; }
         public SemanticVersion MaxVersion { get; set; }
         public bool IsMaxInclusive { get; set; }
-        public bool IsSnapshot { get; set; }
 
         public override string ToString()
         {
-            if (IsSnapshot)
-            {
-                return MinVersion + "-*";
-            }
-
             if (MinVersion != null && IsMinInclusive && MaxVersion == null && !IsMaxInclusive)
             {
                 return MinVersion.ToString();

--- a/src/Microsoft.Framework.Runtime/NuGet/Utility/VersionSpec.cs
+++ b/src/Microsoft.Framework.Runtime/NuGet/Utility/VersionSpec.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Globalization;
 using System.Text;
 
@@ -14,6 +15,7 @@ namespace NuGet
 
         public VersionSpec(SemanticVersion version)
         {
+            IsSnapshot = false;
             IsMinInclusive = true;
             IsMaxInclusive = true;
             MinVersion = version;
@@ -24,9 +26,15 @@ namespace NuGet
         public bool IsMinInclusive { get; set; }
         public SemanticVersion MaxVersion { get; set; }
         public bool IsMaxInclusive { get; set; }
+        public bool IsSnapshot { get; set; }
 
         public override string ToString()
         {
+            if (IsSnapshot)
+            {
+                return MinVersion + "-*";
+            }
+
             if (MinVersion != null && IsMinInclusive && MaxVersion == null && !IsMaxInclusive)
             {
                 return MinVersion.ToString();

--- a/src/Microsoft.Framework.Runtime/NuGet/Utility/VersionUtility.cs
+++ b/src/Microsoft.Framework.Runtime/NuGet/Utility/VersionUtility.cs
@@ -1096,6 +1096,12 @@ namespace NuGet
                 return false;
             }
 
+            if (ideal.VersionFloatBehavior == SemanticVersionFloatBehavior.None &&
+                considering != ideal.MinVersion)
+            {
+                return false;
+            }
+
             if (current == null)
             {
                 // always use version when it's the first valid

--- a/src/Microsoft.Framework.Runtime/NuGet/Utility/VersionUtility.cs
+++ b/src/Microsoft.Framework.Runtime/NuGet/Utility/VersionUtility.cs
@@ -1080,7 +1080,7 @@ namespace NuGet
                 return false;
             }
 
-            if (!ideal.EqualsSnapshot(considering) && !ideal.IsSatisfiedBy(considering))
+            if (!ideal.EqualsSnapshot(considering) && considering < ideal.MinVersion)
             {
                 // Don't use anything that can't be satisfied
                 return false;

--- a/src/Microsoft.Framework.Runtime/NuGet/Utility/VersionUtility.cs
+++ b/src/Microsoft.Framework.Runtime/NuGet/Utility/VersionUtility.cs
@@ -11,6 +11,7 @@ using System.Reflection;
 using System.Runtime.Versioning;
 using System.Text;
 using System.Text.RegularExpressions;
+using Microsoft.Framework.Runtime;
 using NuGet.Resources;
 using CompatibilityMapping = System.Collections.Generic.Dictionary<string, string[]>;
 
@@ -283,6 +284,25 @@ namespace NuGet
             return version;
         }
 
+        public static SemanticVersionRange ParseVersionRange(string value)
+        {
+            var floatBehavior = SemanticVersionFloatBehavior.None;
+
+            // Support snapshot versions
+            if (value.EndsWith("-*"))
+            {
+                floatBehavior = SemanticVersionFloatBehavior.Prerelease;
+                value = value.Substring(0, value.Length - 2);
+            }
+
+            var spec = ParseVersionSpec(value);
+
+            return new SemanticVersionRange(spec)
+            {
+                VersionFloatBehavior = floatBehavior
+            };
+        }
+
         /// <summary>
         /// The version string is either a simple version or an arithmetic range
         /// e.g.
@@ -316,15 +336,6 @@ namespace NuGet
 
             value = value.Trim();
 
-            var isSnapshot = false;
-
-            // Support snapshot versions
-            if (value.EndsWith("-*"))
-            {
-                isSnapshot = true;
-                value = value.Substring(0, value.Length - 2);
-            }
-
             // First, try to parse it as a plain version string
             SemanticVersion version;
             if (SemanticVersion.TryParse(value, out version))
@@ -333,8 +344,7 @@ namespace NuGet
                 result = new VersionSpec
                 {
                     MinVersion = version,
-                    IsMinInclusive = true,
-                    IsSnapshot = isSnapshot
+                    IsMinInclusive = true
                 };
 
                 return true;
@@ -1072,7 +1082,7 @@ namespace NuGet
         public static bool ShouldUseConsidering(
             SemanticVersion current,
             SemanticVersion considering,
-            IVersionSpec ideal)
+            SemanticVersionRange ideal)
         {
             if (considering == null)
             {
@@ -1080,7 +1090,7 @@ namespace NuGet
                 return false;
             }
 
-            if (!ideal.EqualsSnapshot(considering) && considering < ideal.MinVersion)
+            if (!ideal.EqualsFloating(considering) && considering < ideal.MinVersion)
             {
                 // Don't use anything that can't be satisfied
                 return false;
@@ -1092,10 +1102,10 @@ namespace NuGet
                 return true;
             }
 
-            if (ideal.EqualsSnapshot(current) && 
-                ideal.EqualsSnapshot(considering))
+            if (ideal.EqualsFloating(current) &&
+                ideal.EqualsFloating(considering))
             {
-                // favor higher version when they both match a snapshot patter
+                // favor higher version when they both match a floating pattern
                 return current < considering;
             }
 

--- a/src/Microsoft.Framework.Runtime/Project.cs
+++ b/src/Microsoft.Framework.Runtime/Project.cs
@@ -531,32 +531,33 @@ namespace Microsoft.Framework.Runtime
                         }
                     }
 
-                    SemanticVersion dependencyVersion = null;
+                    SemanticVersionRange dependencyVersionRange = null;
 
                     if (!string.IsNullOrEmpty(dependencyVersionValue))
                     {
                         try
                         {
-                            dependencyVersion = VersionUtility.ParseVersionSpec(dependencyVersionValue);
+                            dependencyVersionRange = VersionUtility.ParseVersionRange(dependencyVersionValue);
                         }
                         catch (Exception ex)
                         {
                             throw ProjectFormatException.Create(
-                                ex, 
-                                dependencyVersionToken, 
+                                ex,
+                                dependencyVersionToken,
                                 projectPath);
                         }
                     }
 
-                    results.Add(new LibraryDependency(
-                        library: new Library
+                    results.Add(new LibraryDependency
+                    {
+                        LibraryRange = new LibraryRange
                         {
                             Name = dependency.Key,
-                            RequestedVersion = dependencyVersion,
+                            VersionRange = dependencyVersionRange,
                             IsGacOrFrameworkReference = isGacOrFrameworkReference,
                         },
-                        type: dependencyTypeValue
-                    ));
+                        Type = dependencyTypeValue
+                    });
                 }
             }
         }

--- a/test/Microsoft.Framework.Runtime.Tests/DependencyWalkerFacts.cs
+++ b/test/Microsoft.Framework.Runtime.Tests/DependencyWalkerFacts.cs
@@ -181,7 +181,7 @@ namespace Loader.Tests
 
     public class TestDependencyProvider : IDependencyProvider
     {
-        private readonly IDictionary<Library, Entry> _entries = new Dictionary<Library, Entry>();
+        private readonly IDictionary<LibraryRange, Entry> _entries = new Dictionary<LibraryRange, Entry>();
         public IEnumerable<LibraryDependency> Dependencies { get; set; }
         public FrameworkName FrameworkName { get; set; }
 
@@ -190,11 +190,11 @@ namespace Loader.Tests
             return null;
         }
 
-        public LibraryDescription GetDescription(Library library, FrameworkName frameworkName)
+        public LibraryDescription GetDescription(LibraryRange libraryRange, FrameworkName frameworkName)
         {
-            Trace.WriteLine(string.Format("StubAssemblyLoader.GetDependencies {0} {1} {2}", library.Name, library.Version, frameworkName));
+            Trace.WriteLine(string.Format("StubAssemblyLoader.GetDependencies {0} {1} {2}", libraryRange.Name, libraryRange.VersionRange, frameworkName));
             Entry entry;
-            if (!_entries.TryGetValue(library, out entry))
+            if (!_entries.TryGetValue(libraryRange, out entry))
             {
                 return null;
             }
@@ -204,19 +204,32 @@ namespace Loader.Tests
 
             return new LibraryDescription
             {
-                Identity = new Library { Name = library.Name, Version = library.Version },
+                Identity = new Library { Name = libraryRange.Name, Version = libraryRange.VersionRange.MinVersion },
                 Dependencies = entry.Dependencies
             };
         }
 
         public void Initialize(IEnumerable<LibraryDescription> packages, FrameworkName frameworkName)
         {
-            var d = packages.Select(package => new LibraryDependency(package.Identity)).ToArray();
+            var d = packages.Select(CreateDependency).ToArray();
 
             Trace.WriteLine(string.Format("StubAssemblyLoader.Initialize {0} {1}", d.Aggregate("", (a, b) => a + " " + b), frameworkName));
 
             Dependencies = d;
             FrameworkName = frameworkName;
+        }
+
+        private static LibraryDependency CreateDependency(LibraryDescription libraryDescription)
+        {
+            return new LibraryDependency
+            {
+                LibraryRange = new LibraryRange
+                {
+                    Name = libraryDescription.Identity.Name,
+                    IsGacOrFrameworkReference = libraryDescription.Identity.IsGacOrFrameworkReference,
+                    VersionRange = new SemanticVersionRange(libraryDescription.Identity.Version)
+                }
+            };
         }
 
         public TestDependencyProvider Package(string name, string version)
@@ -231,11 +244,7 @@ namespace Loader.Tests
                 Key = new Library
                 {
                     Name = name,
-                    RequestedVersion = new VersionSpec
-                    {
-                        IsMinInclusive = true,
-                        MinVersion = new SemanticVersion(version),
-                    }
+                    Version = new SemanticVersion(version)
                 }
             };
 
@@ -256,15 +265,14 @@ namespace Loader.Tests
 
             public Entry Needs(string name, string version)
             {
-                Dependencies.Add(new LibraryDependency(new Library
+                Dependencies.Add(new LibraryDependency
                 {
-                    Name = name,
-                    RequestedVersion = new VersionSpec
+                    LibraryRange = new LibraryRange
                     {
-                        IsMinInclusive = true,
-                        MinVersion = new SemanticVersion(version)
+                        Name = name,
+                        VersionRange = new SemanticVersionRange(new SemanticVersion(version))
                     }
-                }));
+                });
 
                 return this;
             }

--- a/test/Microsoft.Framework.Runtime.Tests/DependencyWalkerFacts.cs
+++ b/test/Microsoft.Framework.Runtime.Tests/DependencyWalkerFacts.cs
@@ -226,7 +226,19 @@ namespace Loader.Tests
 
         public TestDependencyProvider Package(string name, string version, Action<Entry> configure)
         {
-            var entry = new Entry { Key = new Library { Name = name, Version = new SemanticVersion(version) } };
+            var entry = new Entry
+            {
+                Key = new Library
+                {
+                    Name = name,
+                    RequestedVersion = new VersionSpec
+                    {
+                        IsMinInclusive = true,
+                        MinVersion = new SemanticVersion(version),
+                    }
+                }
+            };
+
             _entries[entry.Key] = entry;
             configure(entry);
             return this;
@@ -244,10 +256,16 @@ namespace Loader.Tests
 
             public Entry Needs(string name, string version)
             {
-                Dependencies.Add(new LibraryDependency(
-                    name: name,
-                    version: new SemanticVersion(version)
-                ));
+                Dependencies.Add(new LibraryDependency(new Library
+                {
+                    Name = name,
+                    RequestedVersion = new VersionSpec
+                    {
+                        IsMinInclusive = true,
+                        MinVersion = new SemanticVersion(version)
+                    }
+                }));
+
                 return this;
             }
         }

--- a/test/Microsoft.Framework.Runtime.Tests/ProjectFacts.cs
+++ b/test/Microsoft.Framework.Runtime.Tests/ProjectFacts.cs
@@ -61,29 +61,37 @@ namespace Microsoft.Framework.Runtime.Tests
         ""A"": """",
         ""B"": ""1.0-alpha-*"",
         ""C"": ""1.0.0"",
-        ""D"": { ""version"": ""2.0.0"" }
+        ""D"": { ""version"": ""2.0.0"" },
+        ""E"": ""[1.0.0, 1.1.0)""
     }
 }",
 "foo",
 @"c:\foo\project.json");
 
             Assert.NotNull(project.Dependencies);
-            Assert.Equal(4, project.Dependencies.Count);
+            Assert.Equal(5, project.Dependencies.Count);
             var d1 = project.Dependencies[0];
             var d2 = project.Dependencies[1];
             var d3 = project.Dependencies[2];
             var d4 = project.Dependencies[3];
+            var d5 = project.Dependencies[4];
             Assert.Equal("A", d1.Name);
-            Assert.Null(d1.Version);
+            Assert.Null(d1.Library.RequestedVersion);
             Assert.Equal("B", d2.Name);
-            Assert.Equal(SemanticVersion.Parse("1.0-alpha-*"), d2.Version);
-            Assert.True(d2.Version.IsSnapshot);
+            Assert.True(d2.Library.RequestedVersion.IsMinInclusive);
+            Assert.Equal(SemanticVersion.Parse("1.0-alpha"), d2.Library.RequestedVersion.MinVersion);
+            Assert.True(d2.Library.RequestedVersion.IsSnapshot);
             Assert.Equal("C", d3.Name);
-            Assert.Equal(SemanticVersion.Parse("1.0.0"), d3.Version);
-            Assert.False(d3.Version.IsSnapshot);
+            Assert.Equal(SemanticVersion.Parse("1.0.0"), d3.Library.RequestedVersion.MinVersion);
+            Assert.False(d3.Library.RequestedVersion.IsSnapshot);
             Assert.Equal("D", d4.Name);
-            Assert.Equal(SemanticVersion.Parse("2.0.0"), d4.Version);
-            Assert.False(d4.Version.IsSnapshot);
+            Assert.Equal(SemanticVersion.Parse("2.0.0"), d4.Library.RequestedVersion.MinVersion);
+            Assert.False(d4.Library.RequestedVersion.IsSnapshot);
+            Assert.Equal("E", d5.Name);
+            Assert.True(d5.Library.RequestedVersion.IsMinInclusive);
+            Assert.Equal(SemanticVersion.Parse("1.0.0"), d5.Library.RequestedVersion.MinVersion);
+            Assert.Equal(SemanticVersion.Parse("1.1.0"), d5.Library.RequestedVersion.MaxVersion);
+            Assert.False(d5.Library.RequestedVersion.IsMaxInclusive);
         }
 
         [Fact]
@@ -116,14 +124,14 @@ namespace Microsoft.Framework.Runtime.Tests
             Assert.Equal("A", d1.Name);
             Assert.Null(d1.Version);
             Assert.Equal("B", d2.Name);
-            Assert.Equal(SemanticVersion.Parse("1.0-alpha-*"), d2.Version);
-            Assert.True(d2.Version.IsSnapshot);
+            Assert.Equal(SemanticVersion.Parse("1.0-alpha"), d2.Library.RequestedVersion.MinVersion);
+            Assert.True(d2.Library.RequestedVersion.IsSnapshot);
             Assert.Equal("C", d3.Name);
-            Assert.Equal(SemanticVersion.Parse("1.0.0"), d3.Version);
-            Assert.False(d3.Version.IsSnapshot);
+            Assert.Equal(SemanticVersion.Parse("1.0.0"), d3.Library.RequestedVersion.MinVersion);
+            Assert.False(d3.Library.RequestedVersion.IsSnapshot);
             Assert.Equal("D", d4.Name);
-            Assert.Equal(SemanticVersion.Parse("2.0.0"), d4.Version);
-            Assert.False(d4.Version.IsSnapshot);
+            Assert.Equal(SemanticVersion.Parse("2.0.0"), d4.Library.RequestedVersion.MinVersion);
+            Assert.False(d4.Library.RequestedVersion.IsSnapshot);
         }
 
         [Fact]
@@ -156,16 +164,16 @@ namespace Microsoft.Framework.Runtime.Tests
             Assert.Null(d1.Version);
             Assert.True(d1.IsGacOrFrameworkReference);
             Assert.Equal("B", d2.Name);
-            Assert.Equal(SemanticVersion.Parse("1.0-alpha-*"), d2.Version);
-            Assert.True(d2.Version.IsSnapshot);
+            Assert.Equal(SemanticVersion.Parse("1.0-alpha"), d2.Library.RequestedVersion.MinVersion);
+            Assert.True(d2.Library.RequestedVersion.IsSnapshot);
             Assert.True(d2.IsGacOrFrameworkReference);
             Assert.Equal("C", d3.Name);
-            Assert.Equal(SemanticVersion.Parse("1.0.0"), d3.Version);
-            Assert.False(d3.Version.IsSnapshot);
+            Assert.Equal(SemanticVersion.Parse("1.0.0"), d3.Library.RequestedVersion.MinVersion);
+            Assert.False(d3.Library.RequestedVersion.IsSnapshot);
             Assert.True(d3.IsGacOrFrameworkReference);
             Assert.Equal("D", d4.Name);
-            Assert.Equal(SemanticVersion.Parse("2.0.0"), d4.Version);
-            Assert.False(d4.Version.IsSnapshot);
+            Assert.Equal(SemanticVersion.Parse("2.0.0"), d4.Library.RequestedVersion.MinVersion);
+            Assert.False(d4.Library.RequestedVersion.IsSnapshot);
             Assert.True(d4.IsGacOrFrameworkReference);
         }
 

--- a/test/Microsoft.Framework.Runtime.Tests/ProjectFacts.cs
+++ b/test/Microsoft.Framework.Runtime.Tests/ProjectFacts.cs
@@ -76,22 +76,20 @@ namespace Microsoft.Framework.Runtime.Tests
             var d4 = project.Dependencies[3];
             var d5 = project.Dependencies[4];
             Assert.Equal("A", d1.Name);
-            Assert.Null(d1.Library.RequestedVersion);
+            Assert.Null(d1.LibraryRange.VersionRange);
             Assert.Equal("B", d2.Name);
-            Assert.True(d2.Library.RequestedVersion.IsMinInclusive);
-            Assert.Equal(SemanticVersion.Parse("1.0-alpha"), d2.Library.RequestedVersion.MinVersion);
-            Assert.True(d2.Library.RequestedVersion.IsSnapshot);
+            Assert.Equal(SemanticVersion.Parse("1.0-alpha"), d2.LibraryRange.VersionRange.MinVersion);
+            Assert.True(d2.LibraryRange.VersionRange.VersionFloatBehavior == SemanticVersionFloatBehavior.Prerelease);
             Assert.Equal("C", d3.Name);
-            Assert.Equal(SemanticVersion.Parse("1.0.0"), d3.Library.RequestedVersion.MinVersion);
-            Assert.False(d3.Library.RequestedVersion.IsSnapshot);
+            Assert.Equal(SemanticVersion.Parse("1.0.0"), d3.LibraryRange.VersionRange.MinVersion);
+            Assert.False(d3.LibraryRange.VersionRange.VersionFloatBehavior == SemanticVersionFloatBehavior.Prerelease);
             Assert.Equal("D", d4.Name);
-            Assert.Equal(SemanticVersion.Parse("2.0.0"), d4.Library.RequestedVersion.MinVersion);
-            Assert.False(d4.Library.RequestedVersion.IsSnapshot);
+            Assert.Equal(SemanticVersion.Parse("2.0.0"), d4.LibraryRange.VersionRange.MinVersion);
+            Assert.False(d4.LibraryRange.VersionRange.VersionFloatBehavior == SemanticVersionFloatBehavior.Prerelease);
             Assert.Equal("E", d5.Name);
-            Assert.True(d5.Library.RequestedVersion.IsMinInclusive);
-            Assert.Equal(SemanticVersion.Parse("1.0.0"), d5.Library.RequestedVersion.MinVersion);
-            Assert.Equal(SemanticVersion.Parse("1.1.0"), d5.Library.RequestedVersion.MaxVersion);
-            Assert.False(d5.Library.RequestedVersion.IsMaxInclusive);
+            Assert.Equal(SemanticVersion.Parse("1.0.0"), d5.LibraryRange.VersionRange.MinVersion);
+            Assert.Equal(SemanticVersion.Parse("1.1.0"), d5.LibraryRange.VersionRange.MaxVersion);
+            Assert.False(d5.LibraryRange.VersionRange.IsMaxInclusive);
         }
 
         [Fact]
@@ -122,16 +120,16 @@ namespace Microsoft.Framework.Runtime.Tests
             var d3 = targetFrameworkInfo.Dependencies[2];
             var d4 = targetFrameworkInfo.Dependencies[3];
             Assert.Equal("A", d1.Name);
-            Assert.Null(d1.Version);
+            Assert.Null(d1.LibraryRange.VersionRange);
             Assert.Equal("B", d2.Name);
-            Assert.Equal(SemanticVersion.Parse("1.0-alpha"), d2.Library.RequestedVersion.MinVersion);
-            Assert.True(d2.Library.RequestedVersion.IsSnapshot);
+            Assert.Equal(SemanticVersion.Parse("1.0-alpha"), d2.LibraryRange.VersionRange.MinVersion);
+            Assert.True(d2.LibraryRange.VersionRange.VersionFloatBehavior == SemanticVersionFloatBehavior.Prerelease);
             Assert.Equal("C", d3.Name);
-            Assert.Equal(SemanticVersion.Parse("1.0.0"), d3.Library.RequestedVersion.MinVersion);
-            Assert.False(d3.Library.RequestedVersion.IsSnapshot);
+            Assert.Equal(SemanticVersion.Parse("1.0.0"), d3.LibraryRange.VersionRange.MinVersion);
+            Assert.False(d3.LibraryRange.VersionRange.VersionFloatBehavior == SemanticVersionFloatBehavior.Prerelease);
             Assert.Equal("D", d4.Name);
-            Assert.Equal(SemanticVersion.Parse("2.0.0"), d4.Library.RequestedVersion.MinVersion);
-            Assert.False(d4.Library.RequestedVersion.IsSnapshot);
+            Assert.Equal(SemanticVersion.Parse("2.0.0"), d4.LibraryRange.VersionRange.MinVersion);
+            Assert.False(d4.LibraryRange.VersionRange.VersionFloatBehavior == SemanticVersionFloatBehavior.Prerelease);
         }
 
         [Fact]
@@ -161,20 +159,20 @@ namespace Microsoft.Framework.Runtime.Tests
             var d3 = targetFrameworkInfo.Dependencies[2];
             var d4 = targetFrameworkInfo.Dependencies[3];
             Assert.Equal("A", d1.Name);
-            Assert.Null(d1.Version);
-            Assert.True(d1.IsGacOrFrameworkReference);
+            Assert.Null(d1.LibraryRange.VersionRange);
+            Assert.True(d1.LibraryRange.IsGacOrFrameworkReference);
             Assert.Equal("B", d2.Name);
-            Assert.Equal(SemanticVersion.Parse("1.0-alpha"), d2.Library.RequestedVersion.MinVersion);
-            Assert.True(d2.Library.RequestedVersion.IsSnapshot);
-            Assert.True(d2.IsGacOrFrameworkReference);
+            Assert.Equal(SemanticVersion.Parse("1.0-alpha"), d2.LibraryRange.VersionRange.MinVersion);
+            Assert.True(d2.LibraryRange.VersionRange.VersionFloatBehavior == SemanticVersionFloatBehavior.Prerelease);
+            Assert.True(d2.LibraryRange.IsGacOrFrameworkReference);
             Assert.Equal("C", d3.Name);
-            Assert.Equal(SemanticVersion.Parse("1.0.0"), d3.Library.RequestedVersion.MinVersion);
-            Assert.False(d3.Library.RequestedVersion.IsSnapshot);
-            Assert.True(d3.IsGacOrFrameworkReference);
+            Assert.Equal(SemanticVersion.Parse("1.0.0"), d3.LibraryRange.VersionRange.MinVersion);
+            Assert.False(d3.LibraryRange.VersionRange.VersionFloatBehavior == SemanticVersionFloatBehavior.Prerelease);
+            Assert.True(d3.LibraryRange.IsGacOrFrameworkReference);
             Assert.Equal("D", d4.Name);
-            Assert.Equal(SemanticVersion.Parse("2.0.0"), d4.Library.RequestedVersion.MinVersion);
-            Assert.False(d4.Library.RequestedVersion.IsSnapshot);
-            Assert.True(d4.IsGacOrFrameworkReference);
+            Assert.Equal(SemanticVersion.Parse("2.0.0"), d4.LibraryRange.VersionRange.MinVersion);
+            Assert.False(d4.LibraryRange.VersionRange.VersionFloatBehavior == SemanticVersionFloatBehavior.Prerelease);
+            Assert.True(d4.LibraryRange.IsGacOrFrameworkReference);
         }
 
         [Fact]


### PR DESCRIPTION
- Added RequestedVersion to Library as IVersionSpec
- Removed Snapshots from SemanticVersion and added them to
VersionSpec instead.

Things left to implement:
- Adding support for maximums to the runtime and restore algorithms.
- Conflict resolution support
- Possible support for ~1.0 syntax

#442

/cc @lodejard @loudej 