### PR TITLE
Added ProjectFormatException and more detailed errors to DTH

### DIFF
--- a/src/Microsoft.Framework.DesignTimeHost/ApplicationContext.cs
+++ b/src/Microsoft.Framework.DesignTimeHost/ApplicationContext.cs
@@ -8,7 +8,6 @@ using System.IO;
 using System.Linq;
 using System.Runtime.Versioning;
 using System.Threading;
-using Microsoft.CodeAnalysis.Text;
 using Microsoft.Framework.DesignTimeHost.Models;
 using Microsoft.Framework.DesignTimeHost.Models.IncomingMessages;
 using Microsoft.Framework.DesignTimeHost.Models.OutgoingMessages;
@@ -102,6 +101,14 @@ namespace Microsoft.Framework.DesignTimeHost
                 {
                     Message = ex.Message
                 };
+
+                var projectFormatException = ex as ProjectFormatException;
+                if (projectFormatException != null)
+                {
+                    error.Path = projectFormatException.Path;
+                    error.Line = projectFormatException.Line;
+                    error.Column = projectFormatException.Column;
+                }
 
                 var message = new Message
                 {

--- a/src/Microsoft.Framework.DesignTimeHost/Models/OutgoingMessages/ErrorMessage.cs
+++ b/src/Microsoft.Framework.DesignTimeHost/Models/OutgoingMessages/ErrorMessage.cs
@@ -7,5 +7,8 @@ namespace Microsoft.Framework.DesignTimeHost.Models.OutgoingMessages
     public class ErrorMessage
     {
         public string Message { get; set; }
+        public string Path { get; set; }
+        public int Line { get; set; }
+        public int Column { get; set; }
     }
 }

--- a/src/Microsoft.Framework.Runtime/ProjectFormatException.cs
+++ b/src/Microsoft.Framework.Runtime/ProjectFormatException.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Framework.Runtime
+{
+    public sealed class ProjectFormatException : Exception
+    {
+        public ProjectFormatException(string message) :
+            base(message)
+        {
+        }
+
+        public ProjectFormatException(string message, Exception innerException) :
+            base(message, innerException)
+        {
+
+        }
+
+        public string Path { get; private set; }
+        public int Line { get; private set; }
+        public int Column { get; private set; }
+
+        private ProjectFormatException WithLineInfo(IJsonLineInfo lineInfo)
+        {
+            Line = lineInfo.LineNumber;
+            Column = lineInfo.LinePosition;
+
+            return this;
+        }
+
+        public static ProjectFormatException Create(Exception exception, JToken value, string path)
+        {
+            var lineInfo = (IJsonLineInfo)value;
+
+            return new ProjectFormatException(exception.Message, exception)
+            {
+                Path = path
+            }
+            .WithLineInfo(lineInfo);
+        }
+
+        public static ProjectFormatException Create(string message, JToken value, string path)
+        {
+            var lineInfo = (IJsonLineInfo)value;
+
+            return new ProjectFormatException(message)
+            {
+                Path = path
+            }
+            .WithLineInfo(lineInfo);
+        }
+
+        internal static ProjectFormatException Create(JsonReaderException exception, string path)
+        {
+            return new ProjectFormatException(exception.Message, exception)
+            {
+                Path = path,
+                Column = exception.LineNumber,
+                Line = exception.LinePosition
+            };
+        }
+    }
+}


### PR DESCRIPTION
- ProjectFormatException has the project path, line and Column
(1 based), where the exception ocurred in the project.json file.
- Give more specific errors when they aren't just JsonReaderExceptions,
but semantic exceptions within the project format itself (beyond just JSON).
- Added Path, Line and Column to ErrorMessage in DTH

#1052

/cc @BillHiebert 