### PR TITLE
Improve klr

### DIFF
--- a/src/Microsoft.Framework.ApplicationHost/Program.cs
+++ b/src/Microsoft.Framework.ApplicationHost/Program.cs
@@ -114,7 +114,7 @@ namespace Microsoft.Framework.ApplicationHost
         private bool ParseArgs(string[] args, out DefaultHostOptions defaultHostOptions, out string[] outArgs, out int exitCode)
         {
             var app = new CommandLineApplication(throwOnUnexpectedArg: false);
-            app.Name = "k";
+            app.Name = "Microsoft.Framework.ApplicationHost";
             var optionWatch = app.Option("--watch", "Watch file changes", CommandOptionType.NoValue);
             var optionPackages = app.Option("--packages <PACKAGE_DIR>", "Directory containing packages",
                 CommandOptionType.SingleValue);
@@ -149,9 +149,9 @@ namespace Microsoft.Framework.ApplicationHost
             }
             else if (!(app.RemainingArguments.Any() || runCmdExecuted))
             {
-                // If no subcommand/option was specified, show help information
+                // If no subcommand was specified, show error message
                 // and exit immediately with non-zero exit code
-                app.ShowHelp();
+                Console.WriteLine("Please specify the command to run");
                 exitCode = 2;
                 return true;
             }

--- a/src/klr.mono.managed/EntryPoint.cs
+++ b/src/klr.mono.managed/EntryPoint.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using klr.hosting;
 
@@ -14,7 +15,113 @@ public class EntryPoint
         // Set the default lib path to be next to the entry point location
         Environment.SetEnvironmentVariable("KRE_DEFAULT_LIB", Path.GetDirectoryName(typeof(EntryPoint).Assembly.Location));
         Environment.SetEnvironmentVariable("KRE_CONSOLE_HOST", "1");
-        
+
+        arguments = ExpandCommandLineArguments(arguments);
+
+        // Set application base dir
+        var appbaseIndex = arguments.ToList().FindIndex(arg =>
+            string.Equals(arg, "--appbase", StringComparison.OrdinalIgnoreCase));
+        if (appbaseIndex >= 0 && (appbaseIndex < arguments.Length - 1))
+        {
+            Environment.SetEnvironmentVariable("KRE_APPBASE", arguments[appbaseIndex + 1]);
+        }
+
         return RuntimeBootstrapper.Execute(arguments);
+    }
+    
+    private static string[] ExpandCommandLineArguments(string[] arguments)
+    {
+        // If '--appbase' is already given and it has a value, don't need to expand
+        var appbaseIndex = arguments.ToList().FindIndex(arg =>
+            string.Equals(arg, "--appbase", StringComparison.OrdinalIgnoreCase));
+        if (appbaseIndex >= 0 && (appbaseIndex < arguments.Length - 1))
+        {
+            return arguments;
+        }
+
+        var expandedArgs = new List<string>();
+
+        // Copy all arguments (options & values) as is before the project.json/assembly path
+        var pathArgIndex = -1;
+        while (++pathArgIndex < arguments.Length)
+        {
+            var optionValNum = KlrOptionValueNum(arguments[pathArgIndex]);
+
+            // It isn't a klr option, we treat it as the project.json/assembly path
+            if (optionValNum < 0)
+            {
+                break;
+            }
+
+            // Copy the option
+            expandedArgs.Add(arguments[pathArgIndex]);
+
+            // Copy the value if the option has one
+            if (optionValNum > 0 && (++pathArgIndex < arguments.Length))
+            {
+                expandedArgs.Add(arguments[pathArgIndex]);
+            }
+        }
+
+        // No path argument was found, no expansion is needed
+        if (pathArgIndex >= arguments.Length)
+        {
+            return arguments;
+        }
+
+        // Start to expand appbase option from path
+        expandedArgs.Add("--appbase");
+
+        var pathArg = arguments[pathArgIndex];
+        if (pathArg.EndsWith(".exe", StringComparison.OrdinalIgnoreCase) ||
+            pathArg.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+        {
+            // "klr /path/App.dll arg1" --> "klr --appbase /path/ /path/App.dll arg1"
+            // "klr /path/App.exe arg1" --> "klr --appbase /path/ /path/App.exe arg1"
+            expandedArgs.Add(Path.GetDirectoryName(Path.GetFullPath(pathArg)));
+            expandedArgs.AddRange(arguments.Skip(pathArgIndex));
+        }
+        else
+        {
+            var fileName = Path.GetFileName(pathArg);
+            if (string.Equals(fileName, "project.json", StringComparison.OrdinalIgnoreCase))
+            {
+                // "klr /path/project.json run" --> "klr --appbase /path/ Microsoft.Framework.ApplicationHost run"
+                expandedArgs.Add(Path.GetDirectoryName(Path.GetFullPath(pathArg)));
+            }
+            else
+            {
+                // "klr /path/ run" --> "klr --appbase /path/ Microsoft.Framework.ApplicationHost run"
+                expandedArgs.Add(pathArg);
+            }
+
+            expandedArgs.Add("Microsoft.Framework.ApplicationHost");
+            expandedArgs.AddRange(arguments.Skip(pathArgIndex + 1));
+        }
+
+        return expandedArgs.ToArray();
+    }
+
+    private static int KlrOptionValueNum(string candidate)
+    {
+        if (string.Equals(candidate, "--appbase", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(candidate, "--lib", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(candidate, "--packages", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(candidate, "--configuration", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(candidate, "--port", StringComparison.OrdinalIgnoreCase))
+        {
+            return 1;
+        }
+        else if (string.Equals(candidate, "--watch", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(candidate, "--help", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(candidate, "--h", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(candidate, "--?", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(candidate, "--version", StringComparison.OrdinalIgnoreCase))
+        {
+            return 0;
+        }
+
+        // It isn't a klr option
+        return -1;
     }
 }

--- a/src/klr/stdafx.h
+++ b/src/klr/stdafx.h
@@ -9,6 +9,7 @@
 
 #include <stdio.h>
 #include <tchar.h>
+#include <strsafe.h>
 
 
 #define WIN32_LEAN_AND_MEAN             // Exclude rarely-used stuff from Windows headers


### PR DESCRIPTION
parent #1013 #1071 

* `RuntimeBootstrapper` already does the following expansion:
`klr /path/to/MyApplication.dll` --->  `klr --lib /path/to/ MyApplication`.
So we only need to generate `--appbase /path/to/` part in this case

(See https://github.com/aspnet/KRuntime/blob/dev/src/klr.hosting.shared/RuntimeBootstrapper.cs#L298)

* Modifying `src/klr.mono.managed/EntryPoint.cs` to do the expansion on Mono is much more easier. We can even add `--appbase` for klr on Mono in `EntryPoint.cs` if we want it.